### PR TITLE
Support Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
-node_js: "6"
+node_js:
+  - "node"
+  - "6"
+  - "4"
 before_script:
   - npm link
 after_success:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,29 +124,27 @@ var utils = {
 
     Object.keys(envObj).forEach(function (k) {
       if (k.indexOf(prefix) === 0) {
-        (function () {
-          var keypath = k.substring(l).split('__');
-          // Trim empty strings from keypath array
-          var _emptyStringIndex = keypath.indexOf('');
-          while (_emptyStringIndex > -1) {
-            keypath.splice(_emptyStringIndex, 1);
-            _emptyStringIndex = keypath.indexOf('');
-          }
-          var cursor = obj;
-          keypath.forEach(function (_subkey, i) {
-            // (check for _subkey first so we ignore empty strings)
-            // (check for cursor to avoid assignment to primitive objects)
-            if (!_subkey || (typeof cursor === 'undefined' ? 'undefined' : _typeof(cursor)) !== 'object') return;
-            // If this is the last key, just stuff the value in there
-            // Assigns actual value from env variable to final key
-            // (unless it's just an empty string- in that case use the last valid key)
-            if (i === keypath.length - 1) cursor[_subkey] = envObj[k];
-            // Build sub-object if nothing already exists at the keypath
-            if (cursor[_subkey] === undefined) cursor[_subkey] = {};
-            // Increment cursor used to track the object at the current depth
-            cursor = cursor[_subkey];
-          });
-        })();
+        var keypath = k.substring(l).split('__');
+        // Trim empty strings from keypath array
+        var _emptyStringIndex = keypath.indexOf('');
+        while (_emptyStringIndex > -1) {
+          keypath.splice(_emptyStringIndex, 1);
+          _emptyStringIndex = keypath.indexOf('');
+        }
+        var cursor = obj;
+        keypath.forEach(function (_subkey, i) {
+          // (check for _subkey first so we ignore empty strings)
+          // (check for cursor to avoid assignment to primitive objects)
+          if (!_subkey || (typeof cursor === 'undefined' ? 'undefined' : _typeof(cursor)) !== 'object') return;
+          // If this is the last key, just stuff the value in there
+          // Assigns actual value from env variable to final key
+          // (unless it's just an empty string- in that case use the last valid key)
+          if (i === keypath.length - 1) cursor[_subkey] = envObj[k];
+          // Build sub-object if nothing already exists at the keypath
+          if (cursor[_subkey] === undefined) cursor[_subkey] = {};
+          // Increment cursor used to track the object at the current depth
+          cursor = cursor[_subkey];
+        });
       }
     });
     return obj;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -19,7 +19,7 @@ const minimist = require('minimist')(process.argv.slice(2));
  *  * `parse` {Function} used to parse config files.
  */
 function _addConfigFile(file, configs, configFiles, parse) {
-  if (!configFiles.includes(file)) {
+  if (configFiles.indexOf(file) < 0) {
     const fileConfig = cc.file(file);
     if (fileConfig) {
       configs.push(parse(fileConfig));


### PR DESCRIPTION
Using .indexOf() instead of .includes allows config-attendant to work on Node 4,
which is supported until April 2018. See here for details:
https://github.com/nodejs/LTS/tree/af045a4a0e70b0701d9b39c54dae0356c782968a#lts-schedule1